### PR TITLE
Add file io testing

### DIFF
--- a/data/schedule.csv
+++ b/data/schedule.csv
@@ -1,48 +1,48 @@
-do, rj, 1
-rt, js, 1
-km, sh, 1
-va, es, 1
-rt, do, 2
-rj, js, 2
-va, km, 2
-sh, es, 2
-do, js, 3
-rj, rt, 3
-km, es, 3
-sh, va, 3
-km, do, 4
-va, rt, 4
-sh, rj, 4
-es, js, 4
-do, es, 5
-rt, sh, 5
-rt, km, 5
-js, va, 5
-va, do, 6
-km, rt, 6
-sh, js, 6
-es, rt, 6
-do, sh, 7
-js, km, 7
-rj, va, 7
-rt, es, 7
-rj, do, 8
-js, rt, 8
-sh, km, 8
-es, va, 8
-do, rt, 9
-js, rj, 9
-km, va, 9
-es, sh, 9
-js, do, 10 
-rt, rj, 10
-es, km, 10
-va, sh, 10
-km, do, 11
-sh, rj, 11
-va, rt, 11
-es, js, 11
-do, es, 12
-rj, km, 12
-rt, sh, 12
-js, va, 12
+do,rj, 1
+rt,js, 1
+km,sh, 1
+va,es, 1
+rt,do, 2
+rj,js, 2
+va,km, 2
+sh,es, 2
+do,js, 3
+rj,rt, 3
+km,es, 3
+sh,va, 3
+km,do, 4
+va,rt, 4
+sh,rj, 4
+es,js, 4
+do,es, 5
+rt,sh, 5
+rt,km, 5
+js,va, 5
+va,do, 6
+km,rt, 6
+sh,js, 6
+es,rt, 6
+do,sh, 7
+js,km, 7
+rj,va, 7
+rt,es, 7
+rj,do, 8
+js,rt, 8
+sh,km, 8
+es,va, 8
+do,rt, 9
+js,rj, 9
+km,va, 9
+es,sh, 9
+js,do, 10 
+rt,rj, 10
+es,km, 10
+va,sh, 10
+km,do, 11
+sh,rj, 11
+va,rt, 11
+es,js, 11
+do,es, 12
+rj,km, 12
+rt,sh, 12
+js,va, 12

--- a/ffl_predictor/__init__.py
+++ b/ffl_predictor/__init__.py
@@ -1,2 +1,3 @@
 from .team_summarizer import mean_var_scores
 from .season import Season
+from .csv_parser import read_scores

--- a/ffl_predictor/__init__.py
+++ b/ffl_predictor/__init__.py
@@ -1,3 +1,4 @@
 from .team_summarizer import mean_var_scores
 from .season import Season
 from .csv_parser import read_scores
+from .csv_parser import read_schedule

--- a/ffl_predictor/team_summarizer.py
+++ b/ffl_predictor/team_summarizer.py
@@ -3,8 +3,8 @@ import pandas
 
 def mean_var_scores(raw_scores):
     """ Generate table with mean and variance scores for each team """
-    scores_by_team = (raw_scores[['team', 'score']].groupby(
-        ['team'], as_index=False))
+    scores_by_team = (raw_scores[['team', 'score']]
+            .groupby(['team'], as_index=False))
     return pandas.merge(
         scores_by_team.mean().rename(columns={'score': 'mean'}),
         scores_by_team.var().rename(columns={'score': 'var'}))

--- a/tests/test_csv_parser.py
+++ b/tests/test_csv_parser.py
@@ -1,0 +1,30 @@
+""" Unit tests for individual file reading methods """
+import numpy as np
+import pandas as pd
+from context import ffl_predictor
+from helpers import assert_frames_equal
+import pytest
+
+
+@pytest.fixture()
+def scores_file_fixture(tmpdir):
+    p = tmpdir.mkdir("sub").join("fake_scores.csv")
+    p.write("""
+            team1, 1, 1.0
+            team1, 2, 1.0
+            team2, 1, 0.0
+            team2, 2, 10.0
+            team3, 1, 1.0
+            team3, 1, 2.0
+            team3, 1, 3.0
+            team3, 1, 4.0""")
+    return p
+
+def test_read_scores(scores_file_fixture):
+    expected = pd.DataFrame(np.array([
+        ('team1', 1, 1.0), ('team1', 2, 1.0),
+        ('team2', 1, 0.0), ('team2', 2, 10.0),
+        ('team3', 1, 1.0), ('team3', 1, 2.0), ('team3', 1, 3.0), ('team3', 1, 4.0)],
+        dtype=[('team', np.str, 8), ('week', np.int), ('score', np.float)]))
+    assert_frames_equal(expected, ffl_predictor.read_scores(scores_file_fixture.strpath))
+

--- a/tests/test_csv_parser.py
+++ b/tests/test_csv_parser.py
@@ -5,11 +5,10 @@ from context import ffl_predictor
 from helpers import assert_frames_equal
 import pytest
 
-
 @pytest.fixture()
 def scores_file_fixture(tmpdir):
-    p = tmpdir.mkdir("sub").join("fake_scores.csv")
-    p.write("""
+    scores_file = tmpdir.join("fake_scores.csv")
+    scores_file.write("""
             team1, 1, 1.0
             team1, 2, 1.0
             team2, 1, 0.0
@@ -18,7 +17,7 @@ def scores_file_fixture(tmpdir):
             team3, 1, 2.0
             team3, 1, 3.0
             team3, 1, 4.0""")
-    return p
+    return scores_file
 
 def test_read_scores(scores_file_fixture):
     expected = pd.DataFrame(np.array([
@@ -26,5 +25,47 @@ def test_read_scores(scores_file_fixture):
         ('team2', 1, 0.0), ('team2', 2, 10.0),
         ('team3', 1, 1.0), ('team3', 1, 2.0), ('team3', 1, 3.0), ('team3', 1, 4.0)],
         dtype=[('team', np.str, 8), ('week', np.int), ('score', np.float)]))
-    assert_frames_equal(expected, ffl_predictor.read_scores(scores_file_fixture.strpath))
+    assert_frames_equal(ffl_predictor.read_scores(scores_file_fixture.strpath), expected)
 
+@pytest.fixture()
+def schedule_file_fixture(tmpdir):
+    schedule_file = tmpdir.join("fake_schedule.csv")
+    schedule_file.write("""
+                       do,rj, 1
+                       rt,js, 1
+                       km,sh, 1
+                       va,es, 1
+                       rt,do, 2
+                       rj,js, 2
+                       va,km, 2
+                       sh,es, 2
+                       do,js, 3
+                       rj,rt, 3
+                       km,es, 3
+                       sh,va, 3
+                       km,do, 4
+                       va,rt, 4
+                       sh,rj, 4
+                       es,js, 4""")
+    return schedule_file
+
+def test_read_schedule(schedule_file_fixture):
+    expected = pd.DataFrame(np.array([
+        ('do', 'rj', 1),
+        ('rt', 'js', 1),
+        ('km', 'sh', 1),
+        ('va', 'es', 1),
+        ('rt', 'do', 2),
+        ('rj', 'js', 2),
+        ('va', 'km', 2),
+        ('sh', 'es', 2),
+        ('do', 'js', 3),
+        ('rj', 'rt', 3),
+        ('km', 'es', 3),
+        ('sh', 'va', 3),
+        ('km', 'do', 4),
+        ('va', 'rt', 4),
+        ('sh', 'rj', 4),
+        ('es', 'js', 4)],
+        dtype=[('t1', np.str, 8), ('t2', np.str, 8), ('week', np.int)]))
+    assert_frames_equal(ffl_predictor.read_schedule(schedule_file_fixture.strpath), expected, use_close=True)

--- a/tests/test_csv_parser.py
+++ b/tests/test_csv_parser.py
@@ -25,7 +25,9 @@ def test_read_scores(scores_file_fixture):
         ('team2', 1, 0.0), ('team2', 2, 10.0),
         ('team3', 1, 1.0), ('team3', 1, 2.0), ('team3', 1, 3.0), ('team3', 1, 4.0)],
         dtype=[('team', np.str, 8), ('week', np.int), ('score', np.float)]))
-    assert_frames_equal(ffl_predictor.read_scores(scores_file_fixture.strpath), expected)
+    assert_frames_equal(
+            ffl_predictor.read_scores(scores_file_fixture.strpath),
+            expected)
 
 @pytest.fixture()
 def schedule_file_fixture(tmpdir):
@@ -68,4 +70,6 @@ def test_read_schedule(schedule_file_fixture):
         ('sh', 'rj', 4),
         ('es', 'js', 4)],
         dtype=[('t1', np.str, 8), ('t2', np.str, 8), ('week', np.int)]))
-    assert_frames_equal(ffl_predictor.read_schedule(schedule_file_fixture.strpath), expected, use_close=True)
+    assert_frames_equal(
+            ffl_predictor.read_schedule(schedule_file_fixture.strpath),
+            expected)


### PR DESCRIPTION
These tests use pytests built-in [tmpdir](http://doc.pytest.org/en/latest/tmpdir.html) fixture to create a temporary test directory, then adds a file to that temporary directory representing a sample file format.
