### PR TITLE
Individual normal season simulator

### DIFF
--- a/ffl_predictor/__init__.py
+++ b/ffl_predictor/__init__.py
@@ -5,3 +5,4 @@ from .csv_parser import read_scores
 from .csv_parser import read_schedule
 from .season_simulator import RegularSeasonSimulator
 from .season_simulator import RegularSeasonSimulationException
+from .individual_normal_season_simulator import IndividualNormalSeasonSimulator

--- a/ffl_predictor/csv_parser.py
+++ b/ffl_predictor/csv_parser.py
@@ -5,11 +5,11 @@ import pandas
 
 def read_scores(file_path):
     """Load data into fully normalized numpy dataset"""
-    return pandas.DataFrame(
-        np.genfromtxt(
+    return (pandas.DataFrame(np.genfromtxt(
             file_path,
             delimiter=',',
             dtype=[('team', np.str, 8), ('week', np.int), ('score', np.float)]))
+        .set_index(['team', 'week']))
 
 
 def read_schedule(file_path):
@@ -20,6 +20,3 @@ def read_schedule(file_path):
             delimiter=',',
             dtype=[('t1', np.str, 8), ('t2', np.str, 8), ('week', np.int)]))
 
-
-read_scores('./data/scores.csv')
-read_schedule('./data/schedule.csv')

--- a/ffl_predictor/individual_normal_season_simulator.py
+++ b/ffl_predictor/individual_normal_season_simulator.py
@@ -8,7 +8,7 @@ class IndividualNormalSeasonSimulator(RegularSeasonSimulator):
     """ Treats team scores as independent static normal distributions """
 
     def __init__(self, season):
-        super().__init__(season) #TODO: Figure out this syntax
+        super().__init__(season)
 
     def simulate(self):
         all_scheduled = (
@@ -19,12 +19,11 @@ class IndividualNormalSeasonSimulator(RegularSeasonSimulator):
                 .set_index(['team', 'week'])
                 .join(self.season.scores, how='outer')
         )
-        np.random.seed(1)
         unplayed = all_scheduled['score'].isnull()
         combined_data = (mean_var_scores(self.season.scores)
                          .join(all_scheduled[unplayed]))
         all_scheduled['score'][unplayed] = (
-                np.random.normal(size = unplayed.sum())
+                np.random.normal(size=unplayed.sum())
                 * np.sqrt(combined_data['var'])
                 + combined_data['mean'])
         return all_scheduled

--- a/ffl_predictor/individual_normal_season_simulator.py
+++ b/ffl_predictor/individual_normal_season_simulator.py
@@ -11,44 +11,20 @@ class IndividualNormalSeasonSimulator(RegularSeasonSimulator):
         super().__init__(season) #TODO: Figure out this syntax
 
     def simulate(self):
-        distrubution_params = mean_var_scores(self.season.scores)
-        print(self.season.scores)
-
-        new_frame = self.season.scores[['week', 'score']]
-        new_frame.index = self.season.scores['team']
-        print(new_frame)
-        return
-        print(self.season.scores[['week', 'score']])
-        print(pd.DataFrame(self.season.scores[['week', 'score']], index=self.season.scores['team'], columns=['week', 'score']))
-        #TODO: Does append return a new array or same?
-
-    def scores_remaining_per_team(self):
-        """ Ok so to be fastest, I should just generate N std normals and then multiply / add them by the relevant team columns then what? Map these into a new dataframe and append ok smart"""
-        """ Another way to look at this is that I could do the simulations in batch: Generate 100000 of these results at one time by just duplicating the dataframe 100000 times and doing the same process, then splitting it back up into the right size.
-            That batch computation is probably only of limited use though. Not gonna worry about that optimization yet.
-        """
-        #self.season.scores.index = self.season.scores['team']
-        #self.season.scores = self.season.scores[['week', 'score']]
         all_scheduled = (
             self.season.schedule[['t1', 'week']]
                 .rename(columns={'t1': 'team'})
                 .append(self.season.schedule[['t2', 'week']]
                             .rename(columns={'t2': 'team'}))
                 .set_index(['team', 'week'])
-                .join(self.season.scores, on=['team', 'week'], how='outer')
+                .join(self.season.scores, how='outer')
         )
-        print(all_scheduled)
-        return
-        all_scheduled.index = pd.MultiIndex.from_arrays(
-                [all_scheduled['team'], all_scheduled['week']])
-        all_scheduled = all_scheduled['score']
-        unplayed = all_scheduled.isnull()
+        np.random.seed(1)
+        unplayed = all_scheduled['score'].isnull()
         combined_data = (mean_var_scores(self.season.scores)
                          .join(all_scheduled[unplayed]))
-        combined_data['score'] = (
+        all_scheduled['score'][unplayed] = (
                 np.random.normal(size = unplayed.sum())
                 * np.sqrt(combined_data['var'])
                 + combined_data['mean'])
-        combined_data.index = pd.MultiIndex.from_arrays(
-            [combined_data['team'], combined_data['week']])
-        combined_data = combined_data['score']
+        return all_scheduled

--- a/ffl_predictor/individual_normal_season_simulator.py
+++ b/ffl_predictor/individual_normal_season_simulator.py
@@ -1,3 +1,5 @@
+import numpy as np
+import pandas as pd
 from ffl_predictor import RegularSeasonSimulator
 from ffl_predictor import mean_var_scores
 
@@ -10,5 +12,45 @@ class IndividualNormalSeasonSimulator(RegularSeasonSimulator):
 
     def simulate(self):
         distrubution_params = mean_var_scores(self.season.scores)
-        print(distrubution_params)
+        print(self.season.scores)
+
+        new_frame = self.season.scores[['week', 'score']]
+        new_frame.index = self.season.scores['team']
+        print(new_frame)
+        return
+        print(self.season.scores[['week', 'score']])
+        print(pd.DataFrame(self.season.scores[['week', 'score']], index=self.season.scores['team'], columns=['week', 'score']))
         #TODO: Does append return a new array or same?
+
+    def scores_remaining_per_team(self):
+        """ Ok so to be fastest, I should just generate N std normals and then multiply / add them by the relevant team columns then what? Map these into a new dataframe and append ok smart"""
+        """ Another way to look at this is that I could do the simulations in batch: Generate 100000 of these results at one time by just duplicating the dataframe 100000 times and doing the same process, then splitting it back up into the right size.
+            That batch computation is probably only of limited use though. Not gonna worry about that optimization yet.
+        """
+        #self.season.scores.index = self.season.scores['team']
+        #self.season.scores = self.season.scores[['week', 'score']]
+        all_scheduled = (
+            self.season.schedule[['t1', 'week']]
+                .rename(columns={'t1': 'team'})
+                .append(self.season.schedule[['t2', 'week']]
+                            .rename(columns={'t2': 'team'}))
+                .merge(self.season.scores, on=['team', 'week'], how='outer')
+        )
+        all_scheduled.index = pd.MultiIndex.from_arrays(
+                [all_scheduled['team'], all_scheduled['week']])
+        all_scheduled = all_scheduled['score']
+        unplayed = all_scheduled.isnull()
+        combined_data = (mean_var_scores(self.season.scores)
+                         .join(all_scheduled[unplayed]))
+        combined_data['score'] = (
+                np.random.normal(size = unplayed.sum())
+                * np.sqrt(combined_data['var'])
+                + combined_data['mean'])
+        combined_data.index = pd.MultiIndex.from_arrays(
+            [combined_data['team'], combined_data['week']])
+        combined_data = combined_data['score']
+        print(all_scheduled[unplayed_2])
+        print(combined_data)
+        all_scheduled[unplayed_2] = combined_data
+        print(all_scheduled)
+        return all_scheduled

--- a/ffl_predictor/individual_normal_season_simulator.py
+++ b/ffl_predictor/individual_normal_season_simulator.py
@@ -1,0 +1,14 @@
+from ffl_predictor import RegularSeasonSimulator
+from ffl_predictor import mean_var_scores
+
+
+class IndividualNormalSeasonSimulator(RegularSeasonSimulator):
+    """ Treats team scores as independent static normal distributions """
+
+    def __init__(self, season):
+        super().__init__(season) #TODO: Figure out this syntax
+
+    def simulate(self):
+        distrubution_params = mean_var_scores(self.season.scores)
+        print(distrubution_params)
+        #TODO: Does append return a new array or same?

--- a/ffl_predictor/individual_normal_season_simulator.py
+++ b/ffl_predictor/individual_normal_season_simulator.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pandas as pd
+from ffl_predictor import RegularSeasonSimulator
+from ffl_predictor import mean_var_scores
+
+
+class IndividualNormalSeasonSimulator(RegularSeasonSimulator):
+    """ Treats team scores as independent static normal distributions """
+
+    def __init__(self, season):
+        super().__init__(season) #TODO: Figure out this syntax
+
+    def simulate(self):
+        distrubution_params = mean_var_scores(self.season.scores)
+        print(self.season.scores)
+
+        new_frame = self.season.scores[['week', 'score']]
+        new_frame.index = self.season.scores['team']
+        print(new_frame)
+        return
+        print(self.season.scores[['week', 'score']])
+        print(pd.DataFrame(self.season.scores[['week', 'score']], index=self.season.scores['team'], columns=['week', 'score']))
+        #TODO: Does append return a new array or same?
+
+    def scores_remaining_per_team(self):
+        """ Ok so to be fastest, I should just generate N std normals and then multiply / add them by the relevant team columns then what? Map these into a new dataframe and append ok smart"""
+        """ Another way to look at this is that I could do the simulations in batch: Generate 100000 of these results at one time by just duplicating the dataframe 100000 times and doing the same process, then splitting it back up into the right size.
+            That batch computation is probably only of limited use though. Not gonna worry about that optimization yet.
+        """
+        #self.season.scores.index = self.season.scores['team']
+        #self.season.scores = self.season.scores[['week', 'score']]
+        all_scheduled = (
+            self.season.schedule[['t1', 'week']]
+                .rename(columns={'t1': 'team'})
+                .append(self.season.schedule[['t2', 'week']]
+                            .rename(columns={'t2': 'team'}))
+                .set_index(['team', 'week'])
+                .join(self.season.scores, on=['team', 'week'], how='outer')
+        )
+        print(all_scheduled)
+        return
+        all_scheduled.index = pd.MultiIndex.from_arrays(
+                [all_scheduled['team'], all_scheduled['week']])
+        all_scheduled = all_scheduled['score']
+        unplayed = all_scheduled.isnull()
+
+        combined_data = (mean_var_scores(self.season.scores)
+                         .join(all_scheduled[unplayed]))
+        combined_data['score'] = (
+                np.random.normal(size = unplayed.sum())
+                * np.sqrt(combined_data['var'])
+                + combined_data['mean'])
+        combined_data.index = pd.MultiIndex.from_arrays(
+            [combined_data['team'], combined_data['week']])
+        combined_data = combined_data['score']
+        print(all_scheduled[unplayed_2])
+        print(combined_data)
+        all_scheduled[unplayed_2] = combined_data
+        print(all_scheduled)
+        return all_scheduled

--- a/ffl_predictor/individual_normal_season_simulator.py
+++ b/ffl_predictor/individual_normal_season_simulator.py
@@ -34,8 +34,11 @@ class IndividualNormalSeasonSimulator(RegularSeasonSimulator):
                 .rename(columns={'t1': 'team'})
                 .append(self.season.schedule[['t2', 'week']]
                             .rename(columns={'t2': 'team'}))
-                .merge(self.season.scores, on=['team', 'week'], how='outer')
+                .set_index(['team', 'week'])
+                .join(self.season.scores, on=['team', 'week'], how='outer')
         )
+        print(all_scheduled)
+        return
         all_scheduled.index = pd.MultiIndex.from_arrays(
                 [all_scheduled['team'], all_scheduled['week']])
         all_scheduled = all_scheduled['score']
@@ -49,8 +52,3 @@ class IndividualNormalSeasonSimulator(RegularSeasonSimulator):
         combined_data.index = pd.MultiIndex.from_arrays(
             [combined_data['team'], combined_data['week']])
         combined_data = combined_data['score']
-        print(all_scheduled[unplayed_2])
-        print(combined_data)
-        all_scheduled[unplayed_2] = combined_data
-        print(all_scheduled)
-        return all_scheduled

--- a/ffl_predictor/season_simulator.py
+++ b/ffl_predictor/season_simulator.py
@@ -39,8 +39,8 @@ class RegularSeasonSimulator(metaclass=ABCMeta):
 
     @staticmethod
     def _get_played_games_per_team(scores):
-        return (scores[['team', 'week']]
-            .groupby('team', as_index=False)
+        return (scores
+            .groupby(level=['team'])
             .size())
 
     @staticmethod

--- a/ffl_predictor/season_simulator.py
+++ b/ffl_predictor/season_simulator.py
@@ -12,7 +12,7 @@ class RegularSeasonSimulator(metaclass=ABCMeta):
         self.season = season
 
     @abstractmethod
-    def simulate(self, season):
+    def simulate(self):
         pass
 
     @staticmethod

--- a/ffl_predictor/team_summarizer.py
+++ b/ffl_predictor/team_summarizer.py
@@ -3,8 +3,6 @@ import pandas
 
 def mean_var_scores(raw_scores):
     """ Generate table with mean and variance scores for each team """
-    scores_by_team = (raw_scores[['team', 'score']]
-            .groupby(['team'], as_index=False))
-    return pandas.merge(
-        scores_by_team.mean().rename(columns={'score': 'mean'}),
-        scores_by_team.var().rename(columns={'score': 'var'}))
+    scores_by_team = raw_scores.groupby(level=['team'])
+    return (scores_by_team.mean().rename(columns={'score': 'mean'})
+            .join(scores_by_team.var().rename(columns={'score': 'var'})))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,7 +3,7 @@ import numpy.testing as npt
 import pandas as pd
 
 
-def assert_frames_equal(actual, expected, use_close=False):
+def assert_frames_equal(actual, expected, use_close=False, rtol=1e-07, atol=0):
     """
     Source: http://nbviewer.jupyter.org/gist/jiffyclub/ac2e7506428d5e1d587b
     Compare DataFrame items by index and column and
@@ -22,9 +22,12 @@ def assert_frames_equal(actual, expected, use_close=False):
 
     """
     if use_close:
-        comp = npt.assert_allclose
+        def comp(actual, expected):
+            npt.assert_allclose(actual, expected, rtol=rtol, atol=atol)
     else:
         comp = npt.assert_equal
+
+    print(comp)
 
     assert (isinstance(actual, pd.DataFrame) and
             isinstance(expected, pd.DataFrame)), \

--- a/tests/test_csv_parser.py
+++ b/tests/test_csv_parser.py
@@ -20,14 +20,13 @@ def scores_file_fixture(tmpdir):
     return scores_file
 
 def test_read_scores(scores_file_fixture):
-    expected = pd.DataFrame(np.array([
-        ('team1', 1, 1.0), ('team1', 2, 1.0),
-        ('team2', 1, 0.0), ('team2', 2, 10.0),
-        ('team3', 1, 1.0), ('team3', 1, 2.0), ('team3', 1, 3.0), ('team3', 1, 4.0)],
-        dtype=[('team', np.str, 8), ('week', np.int), ('score', np.float)]))
-    assert_frames_equal(
-            ffl_predictor.read_scores(scores_file_fixture.strpath),
-            expected)
+    expected = (pd.DataFrame(np.array([
+            ('team1', 1, 1.0), ('team1', 2, 1.0),
+            ('team2', 1, 0.0), ('team2', 2, 10.0),
+            ('team3', 1, 1.0), ('team3', 1, 2.0), ('team3', 1, 3.0), ('team3', 1, 4.0)],
+            dtype=[('team', np.str, 8), ('week', np.int), ('score', np.float)]))
+        .set_index(['team', 'week']))
+    assert expected.equals(ffl_predictor.read_scores(scores_file_fixture.strpath))
 
 @pytest.fixture()
 def schedule_file_fixture(tmpdir):
@@ -70,6 +69,4 @@ def test_read_schedule(schedule_file_fixture):
         ('sh', 'rj', 4),
         ('es', 'js', 4)],
         dtype=[('t1', np.str, 8), ('t2', np.str, 8), ('week', np.int)]))
-    assert_frames_equal(
-            ffl_predictor.read_schedule(schedule_file_fixture.strpath),
-            expected)
+    assert expected.equals(ffl_predictor.read_schedule(schedule_file_fixture.strpath))

--- a/tests/test_individual_normal_season_simulator.py
+++ b/tests/test_individual_normal_season_simulator.py
@@ -29,9 +29,11 @@ def sample_season():
 
 
 def test_simulate(sample_season):
-    #print(sample_season.scores)
-
-    #IndividualNormalSeasonSimulator(sample_season).simulate()
-    IndividualNormalSeasonSimulator(sample_season).scores_remaining_per_team()
-    #TODO figure out a way to seed the random number generator so I can assert on the actual random values it produces
-    assert 1 == 2
+    expected_scores = (pd.DataFrame(np.array([
+            ('team1', 1, 1.0), ('team1', 2, 1.0), ('team1', 3, 1.0), ('team1', 4, 1.0),
+            ('team2', 1, 0.0), ('team2', 2, 10.0), ('team2', 3, 1.265262), ('team2', 2, -2.587034),
+            ('team3', 1, 1.0), ('team3', 2, 2.0), ('team3', 1, 2.111936), ('team3', 2, -0.127434),
+            ('team4', 1, 3.0), ('team4', 2, 4.0), ('team4', 1, 4.733768), ('team4', 2, 2.961745)],
+        dtype=[('team', np.str, 8), ('week', np.int), ('score', np.float)]))
+        .set_index(['team', 'week']))
+    np.random.seed(1)

--- a/tests/test_individual_normal_season_simulator.py
+++ b/tests/test_individual_normal_season_simulator.py
@@ -1,6 +1,35 @@
 """ Unit test IndividualNormalSeasonSimulator """
+import pytest
+import pandas as pd
+import numpy as np
 from ffl_predictor import IndividualNormalSeasonSimulator
-from test_season_simulator import sample_season
+from ffl_predictor import Season
+
+@pytest.fixture()
+def sample_season():
+    scores = pd.DataFrame(np.array([
+            ('team1', 1, 1.0), ('team1', 2, 1.0),
+            ('team2', 1, 0.0), ('team2', 2, 10.0),
+            ('team3', 1, 1.0), ('team3', 2, 2.0),
+            ('team4', 1, 3.0), ('team4', 2, 4.0)],
+        dtype=[('team', np.str, 8), ('week', np.int), ('score', np.float)]))
+    schedule = pd.DataFrame(np.array([
+            ('team1', 'team2', 1),
+            ('team3', 'team4', 1),
+            ('team1', 'team3', 2),
+            ('team2', 'team4', 2),
+            ('team1', 'team4', 3),
+            ('team2', 'team3', 3),
+            ('team1', 'team3', 4),
+            ('team2', 'team4', 4)],
+        dtype=[('t1', np.str, 8), ('t2', np.str, 8), ('week', np.int)]))
+    return Season(schedule, scores)
+
 
 def test_simulate(sample_season):
-    IndividualNormalSeasonSimulator(sample_season).simulate()
+    #print(sample_season.scores)
+
+    #IndividualNormalSeasonSimulator(sample_season).simulate()
+    IndividualNormalSeasonSimulator(sample_season).scores_remaining_per_team()
+    #TODO figure out a way to seed the random number generator so I can assert on the actual random values it produces
+    assert 1 == 2

--- a/tests/test_individual_normal_season_simulator.py
+++ b/tests/test_individual_normal_season_simulator.py
@@ -27,7 +27,6 @@ def sample_season():
         dtype=[('t1', np.str, 8), ('t2', np.str, 8), ('week', np.int)]))
     return Season(schedule, scores)
 
-
 def test_simulate(sample_season):
     expected_scores = (pd.DataFrame(np.array([
             ('team1', 1, 1.0), ('team1', 2, 1.0), ('team1', 3, 1.0), ('team1', 4, 1.0),

--- a/tests/test_individual_normal_season_simulator.py
+++ b/tests/test_individual_normal_season_simulator.py
@@ -7,12 +7,14 @@ from ffl_predictor import Season
 
 @pytest.fixture()
 def sample_season():
-    scores = pd.DataFrame(np.array([
+    scores = (pd.DataFrame(np.array([
             ('team1', 1, 1.0), ('team1', 2, 1.0),
             ('team2', 1, 0.0), ('team2', 2, 10.0),
             ('team3', 1, 1.0), ('team3', 2, 2.0),
             ('team4', 1, 3.0), ('team4', 2, 4.0)],
         dtype=[('team', np.str, 8), ('week', np.int), ('score', np.float)]))
+        .set_index(['team', 'week']))
+
     schedule = pd.DataFrame(np.array([
             ('team1', 'team2', 1),
             ('team3', 'team4', 1),

--- a/tests/test_individual_normal_season_simulator.py
+++ b/tests/test_individual_normal_season_simulator.py
@@ -1,9 +1,11 @@
 """ Unit test IndividualNormalSeasonSimulator """
+from copy import deepcopy
 import pytest
 import pandas as pd
 import numpy as np
 from ffl_predictor import IndividualNormalSeasonSimulator
 from ffl_predictor import Season
+from helpers import assert_frames_equal
 
 @pytest.fixture()
 def sample_season():
@@ -30,9 +32,17 @@ def sample_season():
 def test_simulate(sample_season):
     expected_scores = (pd.DataFrame(np.array([
             ('team1', 1, 1.0), ('team1', 2, 1.0), ('team1', 3, 1.0), ('team1', 4, 1.0),
-            ('team2', 1, 0.0), ('team2', 2, 10.0), ('team2', 3, 1.265262), ('team2', 2, -2.587034),
-            ('team3', 1, 1.0), ('team3', 2, 2.0), ('team3', 1, 2.111936), ('team3', 2, -0.127434),
-            ('team4', 1, 3.0), ('team4', 2, 4.0), ('team4', 1, 4.733768), ('team4', 2, 2.961745)],
+            ('team2', 1, 0.0), ('team2', 2, 10.0), ('team2', 3, 1.265262), ('team2', 4, -2.587034),
+            ('team3', 1, 1.0), ('team3', 2, 2.0), ('team3', 3, 2.111936), ('team3', 4, -0.127434),
+            ('team4', 1, 3.0), ('team4', 2, 4.0), ('team4', 3, 4.733768), ('team4', 4, 2.961745)],
         dtype=[('team', np.str, 8), ('week', np.int), ('score', np.float)]))
         .set_index(['team', 'week']))
     np.random.seed(1)
+    actual = IndividualNormalSeasonSimulator(sample_season).simulate()
+    assert_frames_equal(actual, expected_scores, use_close=True, atol=.0001)
+
+def test_simulate_different_reuslts(sample_season):
+    sample_season_snapshot = deepcopy(sample_season)
+    assert not IndividualNormalSeasonSimulator(sample_season).simulate().equals(
+            IndividualNormalSeasonSimulator(sample_season).simulate())
+    assert sample_season.scores.equals(sample_season_snapshot.scores)

--- a/tests/test_individual_normal_season_simulator.py
+++ b/tests/test_individual_normal_season_simulator.py
@@ -1,0 +1,6 @@
+""" Unit test IndividualNormalSeasonSimulator """
+from ffl_predictor import IndividualNormalSeasonSimulator
+from test_season_simulator import sample_season
+
+def test_simulate(sample_season):
+    IndividualNormalSeasonSimulator(sample_season).simulate()

--- a/tests/test_season_simulator.py
+++ b/tests/test_season_simulator.py
@@ -17,12 +17,13 @@ class DummyRegularSeasonSimulator(RegularSeasonSimulator):
 
 @pytest.fixture()
 def sample_season():
-    scores = pd.DataFrame(np.array([
+    scores = (pd.DataFrame(np.array([
             ('team1', 1, 1.0), ('team1', 2, 1.0),
             ('team2', 1, 0.0), ('team2', 2, 10.0),
             ('team3', 1, 1.0), ('team3', 2, 2.0),
             ('team4', 1, 3.0), ('team4', 2, 4.0)],
         dtype=[('team', np.str, 8), ('week', np.int), ('score', np.float)]))
+        .set_index(['team', 'week']))
     schedule = pd.DataFrame(np.array([
             ('team1', 'team2', 1),
             ('team3', 'team4', 1),
@@ -38,9 +39,7 @@ def test_valid_season_for_simulation_true(sample_season):
 
 def test_valid_season_for_simulation_extra_score(sample_season):
     with pytest.raises(SeasonStateException):
-        sample_season.scores = sample_season.scores.append(pd.DataFrame(np.array(
-           [('team1', 3, 4.0)],
-            dtype=[('team', np.str, 8), ('week', np.int), ('score', np.float)])))
+        sample_season.scores.loc[('team1', 3), 'score'] =  41.0
         DummyRegularSeasonSimulator(sample_season)
 
 def test_valid_season_for_simulation_duplicate_game(sample_season):
@@ -52,9 +51,8 @@ def test_valid_season_for_simulation_duplicate_game(sample_season):
 
 def test_valid_season_for_simulation_too_many_scores(sample_season):
     with pytest.raises(SeasonStateException):
-        sample_season.scores = sample_season.scores.append(pd.DataFrame(np.array(
-            [('team1', 3, 4.0), ('team1', 4, 4.0)],
-            dtype=[('team', np.str, 8), ('week', np.int), ('score', np.float)])))
+        sample_season.scores.loc[('team1', 3), 'score'] =  4.0
+        sample_season.scores.loc[('team1', 4), 'score'] =  4.0
         DummyRegularSeasonSimulator(sample_season)
 
 def test_has_unplayed_games_true(sample_season):
@@ -62,10 +60,8 @@ def test_has_unplayed_games_true(sample_season):
 
 def test_has_unplayed_games_false(sample_season):
     with pytest.raises(RegularSeasonSimulationException):
-        sample_season.scores = sample_season.scores.append(pd.DataFrame(np.array([
-                ('team1', 4, 4.0),
-                ('team2', 4, 4.0),
-                ('team3', 4, 4.0),
-                ('team4', 3, 4.0)],
-            dtype=[('team', np.str, 8), ('week', np.int), ('score', np.float)])))
+        sample_season.scores.loc[('team1', 4), 'score'] =  4.0
+        sample_season.scores.loc[('team2', 4), 'score'] =  4.0
+        sample_season.scores.loc[('team3', 4), 'score'] =  4.0
+        sample_season.scores.loc[('team4', 3), 'score'] =  4.0
         DummyRegularSeasonSimulator(sample_season)

--- a/tests/test_team_summarizer.py
+++ b/tests/test_team_summarizer.py
@@ -8,11 +8,13 @@ from helpers import assert_frames_equal
 
 def test_mean_var_scores():
     """ Test accurate summarizing of mean and variance of scores for individual teams """
-    raw_data = pd.DataFrame(np.array([
+    raw_data = (pd.DataFrame(np.array([
         ('team1', 1, 1.0), ('team1', 2, 1.0),
         ('team2', 1, 0.0), ('team2', 2, 10.0),
         ('team3', 1, 1.0), ('team3', 1, 2.0), ('team3', 1, 3.0), ('team3', 1, 4.0)],
         dtype=[('team', np.str, 8), ('week', np.int), ('score', np.float)]))
+        .set_index(['team', 'week']))
+
 
     expected = pd.DataFrame({
         'team1': [1, 0],
@@ -20,8 +22,7 @@ def test_mean_var_scores():
         'team3': [2.5, 5/3]
       }) \
      .transpose() \
-     .reset_index(level=0) \
-     .rename(columns={'index': 'team', 0: 'mean', 1: 'var'})
+     .rename(columns={0: 'mean', 1: 'var'})
 
     actual = ffl_predictor.mean_var_scores(raw_data)
     assert_frames_equal(expected, actual, use_close=True)


### PR DESCRIPTION
The added functionality here is a season simulator for a single season which builds a normal distribution for each team individually.

There's also a separate change happening here where I'm migrating our ```Season.scores``` object to use [indices](http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Index.html). In this case we're actually using a [MultiIndex](http://pandas.pydata.org/pandas-docs/stable/advanced.html), with both the team and week representing an index to a score. This should leave all other functionality unaffected, though it's very likely to cause merge conflicts with other branches.