### PR TITLE
import test project in test_season_simulator

### DIFF
--- a/tests/test_season_simulator.py
+++ b/tests/test_season_simulator.py
@@ -1,6 +1,7 @@
 """ Unit test RegularSeasonSimulator base class """
 import numpy as np
 import pandas as pd
+from context import ffl_predictor
 from ffl_predictor import Season
 from ffl_predictor import SeasonStateException
 from ffl_predictor import RegularSeasonSimulator


### PR DESCRIPTION
Unnecessary when running all project tests, I assume because it runs in a single session and it gets imported in a different test. But if you run just this test file, it can't find the ```ffl_predictor``` module.